### PR TITLE
[WIP] feat: Support org-file parsing to hiccup content

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,4 +30,5 @@
   http-kit            {:mvn/version "2.3.0"}
   compojure           {:mvn/version "1.6.1"}
   watchtower          {:mvn/version "0.1.1"}
+  clj-org/clj-org     {:mvn/version "0.0.2"}
   com.taoensso/timbre {:mvn/version "4.10.0"}}}

--- a/example/blog/about.org
+++ b/example/blog/about.org
@@ -1,0 +1,27 @@
+#+TITLE: Sur Moi
+#+TAGS: foo bar baz
+
+* A blog page!
+
+Now /this/ is content!
+
+
+** A subheading
+
+Woah
+
+* What about formatting?
+
+A list?
+
+- *BOLD*
+- /Italic/
+- ~fixed-width~
+
+#+BEGIN_SRC clojure
+(defn hello
+  ([] "Greetings, nerd")
+  ([name] (format "Greetings %s" name)))
+
+(hello "friend")
+#+END_SRC

--- a/example/site.clj
+++ b/example/site.clj
@@ -13,7 +13,15 @@
     (stylesheet global-style)]
    [:body content]])
 
+(def-asset about-page
+  {:path "/about.html"
+   :type :html
+   :data (let [{title :title
+                content :content}
+               (parse-org "./example/blog/about.org")]
+           (page title content))})
+
 (def-asset home-page
   {:path "/index.html"
    :type :html
-   :data (page "Hello world" [:p "This is magic"])})
+   :data (page "Hello world" [:a {:href (asset-path about-page)} "This is a blog link."])})

--- a/src/teknql/statik/core.clj
+++ b/src/teknql/statik/core.clj
@@ -7,6 +7,7 @@
             [garden.color]
             [garden.stylesheet]
             [garden.units]
+            [clj-org.org]
             [clojure.string :as str])
   (:refer-clojure :exclude [compile]))
 
@@ -69,7 +70,8 @@
   '[garden.core
     garden.stylesheet
     garden.color
-    garden.units])
+    garden.units
+    clj-org.org])
 
 (defn- ns->src-path
   "Utility to take a required namespace and load a src path with it"

--- a/src/teknql/statik/core.clj
+++ b/src/teknql/statik/core.clj
@@ -70,8 +70,7 @@
   '[garden.core
     garden.stylesheet
     garden.color
-    garden.units
-    clj-org.org])
+    garden.units])
 
 (defn- ns->src-path
   "Utility to take a required namespace and load a src path with it"
@@ -82,6 +81,12 @@
         (str/replace "-" "_")
         (str/replace "." "/"))
     ".clj"))
+
+(defn parse-org [path]
+  "Take a path and return a map of title and content."
+  (-> path
+      (slurp)
+      (clj-org.org/parse-org)))
 
 (defn eval-string
   "Ealuates the provided string. Returns a list of assets defined by the file."
@@ -103,6 +108,7 @@
                               'user) {'def-asset       def-asset
                                       'asset-path      asset-path
                                       'stylesheet      stylesheet
+                                      'parse-org       parse-org
                                       'register-asset! #(swap! assets conj %)}}
                          (map (juxt identity ns-interns) included-namespaces))})
     @assets))


### PR DESCRIPTION
Opening this PR so you can see where I'm at here. Turns out there's a library that exposes an `org->hiccup function` -- wondrous! Sadly, it only takes a string, so I tried slurping it and realized ~sci doesn't support~ we didn't expose `slurp` in the injected namespaces. Ok, understood. Looks like I'll need to do it in `core.clj` or something.

Basically just putting this up so I have a place to talk it.